### PR TITLE
chore: tidy rancher workflow formatting

### DIFF
--- a/.github/workflows/rancher.yaml
+++ b/.github/workflows/rancher.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:line-length
+---
 name: Deploy Rancher (NodePort via NPM) - One Click
 
 concurrency:
@@ -11,7 +13,7 @@ defaults:
   run:
     shell: bash
 
-on:
+'on':
   workflow_dispatch:
     inputs:
       nodePort:
@@ -23,7 +25,7 @@ on:
         required: false
         default: "2"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - ".github/workflows/deploy-rancher.yml"
       - "k8s/**"
@@ -83,40 +85,43 @@ jobs:
           set -euo pipefail
           mkdir -p "$HOME/.kube"
           python - <<'PY'
-import base64, binascii, os, pathlib, re
+          import base64
+          import os
+          import pathlib
+          import re
 
-raw = os.environ.get("KUBECONFIG_B64","").strip()
+          raw = os.environ.get("KUBECONFIG_B64", "").strip()
 
-# Lepas kutip pembungkus kalau ada
-if (raw.startswith("'") and raw.endswith("'")) or (raw.startswith('"') and raw.endswith('"')):
-    raw = raw[1:-1].strip()
+          # Lepas kutip pembungkus kalau ada
+          if (raw.startswith("'") and raw.endswith("'")) or (raw.startswith('"') and raw.endswith('"')):
+              raw = raw[1:-1].strip()
 
-# Deteksi apakah base64 (tidak mengandung kata kunci kubeconfig)
-looks_like_b64 = re.fullmatch(r'[A-Za-z0-9+/=\s]+', raw or '') is not None and 'apiVersion' not in raw
+          # Deteksi apakah base64 (tidak mengandung kata kunci kubeconfig)
+          looks_like_b64 = re.fullmatch(r'[A-Za-z0-9+/=\s]+', raw or '') is not None and 'apiVersion' not in raw
 
-# Jika bukan base64 dan ada literal "\n", ubah ke newline asli
-if not looks_like_b64 and r'\n' in raw:
-    raw = raw.replace(r'\n','\n')
+          # Jika bukan base64 dan ada literal "\\n", ubah ke newline asli
+          if not looks_like_b64 and "\\n" in raw:
+              raw = raw.replace("\\n", "\n")
 
-target = pathlib.Path(os.environ["HOME"])/".kube"/"config"
-target.parent.mkdir(parents=True, exist_ok=True)
+          target = pathlib.Path(os.environ["HOME"]) / ".kube" / "config"
+          target.parent.mkdir(parents=True, exist_ok=True)
 
-content = None
-try:
-    decoded = base64.b64decode(raw)
-            text = decoded.decode('utf-8', errors='strict')
-            if "apiVersion" in text and "clusters" in text:
-                content = text
-            else:
-                raise ValueError("decoded payload not kubeconfig")
-            except Exception:
-                content = raw
+          content = None
+          try:
+              decoded = base64.b64decode(raw)
+              text = decoded.decode('utf-8', errors='strict')
+              if "apiVersion" in text and "clusters" in text:
+                  content = text
+              else:
+                  raise ValueError("decoded payload not kubeconfig")
+          except Exception:
+              content = raw
 
-            if content and not content.endswith("\n"):
-                content += "\n"
+          if content and not content.endswith("\n"):
+              content += "\n"
 
-            target.write_text(content)
-            PY
+          target.write_text(content)
+          PY
           chmod 600 "$HOME/.kube/config"
           echo "ℹ️ Kube context:" && kubectl config current-context || true
           echo "ℹ️ Cluster info:" && kubectl cluster-info


### PR DESCRIPTION
## Summary
- add a yamllint directive and document start marker to the Rancher workflow
- quote the `on` key and tighten list bracket spacing for consistency
- realign the embedded kubeconfig restoration Python script so indentation stays valid YAML

## Testing
- yamllint .github/workflows/rancher.yaml
- python -c "import yaml; yaml.safe_load(open('.github/workflows/rancher.yaml')); print('ok')"


------
https://chatgpt.com/codex/tasks/task_e_68cd0189fdc0833089306439ecab4411