### PR TITLE
Extend Rancher startup probe tolerance in workflow

### DIFF
--- a/.github/workflows/rancher.yaml
+++ b/.github/workflows/rancher.yaml
@@ -41,6 +41,9 @@ jobs:
     env:
       NODEPORT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.nodePort || '32080' }}
       RANCHER_REPLICAS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.replicas || '2' }}
+      # Memperpanjang toleransi startup probe agar bootstrap Rancher tidak dipotong sebelum waktunya.
+      RANCHER_STARTUP_FAILURE_THRESHOLD: '30'
+      RANCHER_STARTUP_TIMEOUT_SECONDS: '10'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -203,6 +206,7 @@ jobs:
           RANCHER_REPLICAS: ${{ env.RANCHER_REPLICAS }}
         run: |
           set -euo pipefail
+          # Memberi waktu lebih lama bagi Rancher untuk bootstrap sehingga startup probe tidak memicu restart prematur.
           helm upgrade --install "$RELEASE" rancher-latest/rancher \
             -n "$NAMESPACE" \
             --wait \
@@ -210,7 +214,9 @@ jobs:
             --set hostname="${RANCHER_HOSTNAME}" \
             --set replicas=${RANCHER_REPLICAS} \
             --set ingress.enabled=false \
-            --set tls=external
+            --set tls=external \
+            --set startupProbe.failureThreshold=${RANCHER_STARTUP_FAILURE_THRESHOLD} \
+            --set startupProbe.timeoutSeconds=${RANCHER_STARTUP_TIMEOUT_SECONDS}
 
       - name: Wait rollout Rancher
         run: |


### PR DESCRIPTION
## Summary
- add startup probe tuning variables so Rancher gets more time to finish bootstrapping
- configure helm upgrade command to apply the relaxed timeout values with inline documentation

## Testing
- ~/.local/bin/yamllint .github/workflows/rancher.yaml

------
https://chatgpt.com/codex/tasks/task_e_68cd085077cc8330afcf78c1bd6828c0